### PR TITLE
Bugfix: offline mode is sometimes broken during remote debugging

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,10 @@ const RequiresConnection = (WhenOnline, WhenOffline) => class RequiresConnection
 
     let connect = (isConnected) => this.setState({ isConnected })
 
-    NetInfo.isConnected.fetch().done(connect)
-    NetInfo.isConnected.addEventListener('change', connect)
+    NetInfo.isConnected.fetch().done((isConnected) => {
+      connect(isConnected)
+      NetInfo.isConnected.addEventListener('change', connect)
+    })
   }
 
   render () {


### PR DESCRIPTION
- subscribe to mode changes after the connection status is initialized.
  (bug was caused by a race condition when app is loaded between `fetch` and `change`)
