### PR TITLE
Replaced deprecated stuff in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,11 +14,11 @@ const RequiresConnection = (WhenOnline, WhenOffline) => class RequiresConnection
   }
 
   componentDidMount () {
-    let connect = (reach) => this.setState({ isConnected: reach !== 'none' })
+    let connect = ({ type }) => this.setState({ isConnected: type !== 'none' })
 
-    NetInfo.fetch().done((reach) => {
+    NetInfo.getConnectionInfo().done((reach) => {
       connect(reach)
-      NetInfo.addEventListener('change', connect)
+      NetInfo.addEventListener('connectionChange', connect)
     })
   }
 


### PR DESCRIPTION
- `NetInfo.fetch()` is deprecated; changed to `NetInfo.getConnectionInfo()`.
- The `'change'` event for `NetInfo.addEventListener()` is deprecated; changed to `'connectionChange'`.
- Modified the event handler called `connect` to pick off and use the `type` property from the `NetInfo.getConnectionInfo()` promise object called `reach`.

See the associated documentation from React Native [here](https://facebook.github.io/react-native/releases/0.49/docs/netinfo.html#addeventlistener).