### PR TITLE
Add example code and permissions for Android OS

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="com.example">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
       android:allowBackup="true"

--- a/example/index.android.js
+++ b/example/index.android.js
@@ -10,6 +10,7 @@ import React, {
   Text,
   View
 } from 'react-native';
+import RequiresConnection from 'react-native-offline-mode'
 
 class example extends Component {
   render() {
@@ -28,6 +29,16 @@ class example extends Component {
     );
   }
 }
+
+class OfflineClass extends Component {
+  render() {
+    return (
+      <Text>Oh snap! You're offline!</Text>
+    )
+  }
+}
+
+const offlineFunction = () => <Text>Oh noes, you're out of internetz!</Text>
 
 const styles = StyleSheet.create({
   container: {
@@ -48,4 +59,5 @@ const styles = StyleSheet.create({
   },
 });
 
-AppRegistry.registerComponent('example', () => example);
+//AppRegistry.registerComponent('example', () => RequiresConnection(example, OfflineClass));
+AppRegistry.registerComponent('example', () => RequiresConnection(example, offlineFunction));


### PR DESCRIPTION
Resolves #12 .

Hey @rauchy, I wanted to try it over my Android projects and I noticed the example code was missing. I added it along with the needed permission (as I have done for a similar component of mine in the past) but It doesn't work; in the app loads but it doesn't show the "offline component" and in device the app doesn't load at all. Maybe we need to upgrade RN? What do you think?

The code looks legit to my eyes, but please have a look as well.